### PR TITLE
Read password from stdin

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"syscall"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/kless/osutil/user/crypt/sha512_crypt"
+	"github.com/mattn/go-isatty"
 )
 
 // Exit codes are int values that represent an exit code for a particular error.
@@ -45,17 +52,59 @@ func (cli *CLI) Run(args []string) int {
 		return ExitCodeOK
 	}
 
-	if flags.Arg(0) == "" {
+	var rawPassword []byte
+	if flags.Arg(0) != "" {
+		rawPassword = []byte(flags.Arg(0))
+	} else {
+		var err error
+		rawPassword, err = readPasswordFromStdin()
+		if err != nil {
+			fmt.Fprintln(cli.errStream, err)
+			return ExitCodeError
+		}
+	}
+	if len(rawPassword) == 0 {
 		fmt.Fprintln(cli.errStream, "Please specify a password")
 		return ExitCodeError
 	}
 
 	c := sha512_crypt.New()
-	v, err := c.Generate([]byte(flags.Arg(0)), []byte{})
+	v, err := c.Generate(rawPassword, []byte{})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitCodeError
 	}
 	fmt.Println(v)
 	return ExitCodeOK
+}
+
+func readPasswordFromStdin() ([]byte, error) {
+	if isatty.IsTerminal(os.Stdin.Fd()) {
+		// Read password from terminal without echo back
+		var err error
+		fmt.Print("Enter password: ")
+		rawPassword, err := terminal.ReadPassword(int(syscall.Stdin))
+		fmt.Println()
+		if err != nil {
+			return nil, err
+		}
+		fmt.Print("Retype password: ")
+		verify, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return nil, err
+		}
+		fmt.Println()
+		if !bytes.Equal(rawPassword, verify) {
+			return nil, errors.New("Sorry, passwords do not match")
+		}
+		return rawPassword, nil
+	} else {
+		// Read password from stdin (not a terminal)
+		s := bufio.NewScanner(os.Stdin)
+		if s.Scan() {
+			return s.Bytes(), nil
+		}
+		return nil, s.Err()
+	}
+
 }


### PR DESCRIPTION
Hello.

This patch enables to read a password from stdin (terminal or not terminal).
I don't want to specify a password by command line arguments, because it will be recorded in a shell history.

From terminal with verification.

```
$ stns-passwd
Enter password:
Retype password:
$6$rxhkgOR0Y4GLrp00$FOQG0Gyc2zrufFtB9UEs8I83W.....
```

From stdin.

```
$ echo "password" | stns-passwd
$6$bvTxenVA3H37930p$mEgwpwH8SHriqsBHMqOxSf....
```
