### PR TITLE
Update tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go:
+  - 1.6.3
+  - tip

--- a/cli.go
+++ b/cli.go
@@ -74,7 +74,7 @@ func (cli *CLI) Run(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitCodeError
 	}
-	fmt.Println(v)
+	fmt.Fprintln(cli.outStream, v)
 	return ExitCodeOK
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -22,30 +22,3 @@ func TestRun_versionFlag(t *testing.T) {
 		t.Errorf("expected %q to eq %q", errStream.String(), expected)
 	}
 }
-
-func TestRun_sFlag(t *testing.T) {
-	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
-	cli := &CLI{outStream: outStream, errStream: errStream}
-	args := strings.Split("./stns-passwd -s", " ")
-
-	status := cli.Run(args)
-	_ = status
-}
-
-func TestRun_cFlag(t *testing.T) {
-	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
-	cli := &CLI{outStream: outStream, errStream: errStream}
-	args := strings.Split("./stns-passwd -c", " ")
-
-	status := cli.Run(args)
-	_ = status
-}
-
-func TestRun_mFlag(t *testing.T) {
-	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
-	cli := &CLI{outStream: outStream, errStream: errStream}
-	args := strings.Split("./stns-passwd -m", " ")
-
-	status := cli.Run(args)
-	_ = status
-}

--- a/cli_test.go
+++ b/cli_test.go
@@ -22,3 +22,22 @@ func TestRun_versionFlag(t *testing.T) {
 		t.Errorf("expected %q to eq %q", errStream.String(), expected)
 	}
 }
+
+func TestRun(t *testing.T) {
+	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
+	cli := &CLI{outStream: outStream, errStream: errStream}
+	args := strings.Split("./stns-passwd helloworld", " ")
+
+	status := cli.Run(args)
+	if status != ExitCodeOK {
+		t.Errorf("expected %d to eq %d", status, ExitCodeOK)
+	}
+
+	if len(errStream.String()) != 0 {
+		t.Error("errStream must be empty")
+	}
+
+	if len(outStream.String()) == 0 {
+		t.Error("outStream must not be empty")
+	}
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -41,3 +41,23 @@ func TestRun(t *testing.T) {
 		t.Error("outStream must not be empty")
 	}
 }
+
+func TestRun_emptyPassword(t *testing.T) {
+	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
+	cli := &CLI{outStream: outStream, errStream: errStream}
+	args := strings.Split("./stns-passwd ", " ")
+
+	status := cli.Run(args)
+	if status != ExitCodeError {
+		t.Errorf("expected %d to eq %d", status, ExitCodeError)
+	}
+
+	expected := "Please specify a password"
+	if !strings.Contains(errStream.String(), expected) {
+		t.Errorf("expected %q to eq %q", errStream.String(), expected)
+	}
+
+	if len(outStream.String()) != 0 {
+		t.Error("outStream must be empty")
+	}
+}


### PR DESCRIPTION
`cli.go` had dropped *Flags (s, m, c) so I removes these tests from cli_test.go.
And I add some tests and fix codes:
- `cli.Run` use cli.outStream for testing to output passphrase. (TestRun)
-  stns-password should return error if inputting empty password. (TestRun_emptyPassword)
